### PR TITLE
CB-12008 : autosave by default proposal for cordova@7

### DIFF
--- a/proposals/autosave-by-default.md
+++ b/proposals/autosave-by-default.md
@@ -13,8 +13,13 @@ Autosave will be the default option.
 Example: cordova platform add ios
 This command will automatically save the ios platform.
 Include a --no-save flag to not save.
-Example: cordova platform add ios --no-save
+Example: cordova platform add ios --nosave
 This command will allow the ios platform to NOT be saved.
+
+### Notes
+Autosave will only be used in the cli right now (not cordova-lib).
+If you're using cordova-lib directly, you will still need to use the
+--save flag.
 
 ### Future Goals
 Include a global config to turn autosave off for cordova.
@@ -24,16 +29,14 @@ https://issues.apache.org/jira/browse/CB-11982
 https://issues.apache.org/jira/browse/CB-12008
 
 ### Motivation
- Our analytics show --save usage is pretty low (presumably due to people not knowing about it). By having autosave as the default, users won’t have to worry about remembering to save. If users don’t want to save, there are options to opt out of saving with the new --no-save flag.
+ Our analytics show --save usage is pretty low (presumably due to people not knowing about it). By having autosave as the default, users won’t have to worry about remembering to save. If users don’t want to save, there are options to opt out of saving with the new --nosave flag.
 
 ### Use Cases/Tests:
-1. Cordova platform add ios (saves to package.json/config.xml and installed platform list)
-2. Cordova platform remove ios (remove from package.json/config.xml and installed platform list)
-3. Cordova plugin add cordova-plugin-camera (saves to package.json/config.xml and installed plugin list)
-4. Cordova plugin remove cordova-plugin-camera (removes from package.json/config.xml and installed plugin list)
-5. Cordova platform add ios --no-save (does not save to package.json/config.xml, ONLY the installed platform list)
-6. Cordova platform remove ios --no-save (does not remove from package.json/config.xml, ONLY the installed platform list) What will it 
-7. Cordova plugin add cordova-plugin-camera--no-save (does not save to package.json/config.xml, ONLY the installed plugin list)
-8. Cordova plugin remove cordova-plugin-camera --no-save (does not remove from package.json/config.xml, ONLY the installed plugin list)
-9. Check that without --save, it should successfully add and remove a plugin with variables
-10. Check that without --save, it should successfully add and remove multiple plugins
+1. Cordova platform add ios, expect save to be true.
+2. Cordova platform remove ios, expect save to be true.
+3. Cordova plugin add cordova-plugin-camera, expect save to be true.
+4. Cordova plugin remove cordova-plugin-camera, expect save to be true.
+5. Cordova platform add ios --nosave, expect save to be false.
+6. Cordova platform remove ios --nosave, expect save to be false. 
+7. Cordova plugin add cordova-plugin-camera--nosave, expect save to be false.
+8. Cordova plugin remove cordova-plugin-camera --nosave, expect save to be false.

--- a/proposals/autosave-by-default.md
+++ b/proposals/autosave-by-default.md
@@ -1,0 +1,39 @@
+# Autosave by default for cordova@7 Proposal
+Status : Proposed
+
+## Current
+To save or remove dependencies, users must include the --save flag.
+
+Examples: 
+cordova platform add ios --save
+cordova plugin add cordova-plugin-camera --save
+
+## Proposal
+Autosave will be the default option.
+Example: cordova platform add ios
+This command will automatically save the ios platform.
+Include a --no-save flag to not save.
+Example: cordova platform add ios --no-save
+This command will allow the ios platform to NOT be saved.
+
+### Future Goals
+Include a global config to turn autosave off for cordova.
+https://issues.apache.org/jira/browse/CB-11982
+
+### Links
+https://issues.apache.org/jira/browse/CB-12008
+
+### Motivation
+ Our analytics show --save usage is pretty low (presumably due to people not knowing about it). By having autosave as the default, users won’t have to worry about remembering to save. If users don’t want to save, there are options to opt out of saving with the new --no-save flag.
+
+### Use Cases/Tests:
+1. Cordova platform add ios (saves to package.json/config.xml and installed platform list)
+2. Cordova platform remove ios (remove from package.json/config.xml and installed platform list)
+3. Cordova plugin add cordova-plugin-camera (saves to package.json/config.xml and installed plugin list)
+4. Cordova plugin remove cordova-plugin-camera (removes from package.json/config.xml and installed plugin list)
+5. Cordova platform add ios --no-save (does not save to package.json/config.xml, ONLY the installed platform list)
+6. Cordova platform remove ios --no-save (does not remove from package.json/config.xml, ONLY the installed platform list) What will it 
+7. Cordova plugin add cordova-plugin-camera--no-save (does not save to package.json/config.xml, ONLY the installed plugin list)
+8. Cordova plugin remove cordova-plugin-camera --no-save (does not remove from package.json/config.xml, ONLY the installed plugin list)
+9. Check that without --save, it should successfully add and remove a plugin with variables
+10. Check that without --save, it should successfully add and remove multiple plugins


### PR DESCRIPTION
Proposal: Autosave will be the default option (when saving or removing dependencies) instead of using the --save flag.